### PR TITLE
Allow to specify search buffer size

### DIFF
--- a/src/PRS/Compression.cs
+++ b/src/PRS/Compression.cs
@@ -6,7 +6,7 @@ namespace PSO.PRS
 {
     internal class Compression
     {
-        internal static void Compress(Context ctx)
+        internal static void Compress(Context ctx, int searchBufferSize = 8176)
         {
             while (ctx.src_pos < ctx.src.Length)
             {
@@ -14,7 +14,7 @@ namespace PSO.PRS
                 int length = 0;
                 int mlen = 0;
 
-                for (int y = (ctx.src_pos - 1); (y >= 0) && (y >= (ctx.src_pos - 0x1FF0)) && mlen < 256; y--)
+                for (int y = (ctx.src_pos - 1); (y >= 0) && (y >= (ctx.src_pos - searchBufferSize)) && mlen < 256; y--)
                 {
                     mlen = 1;
                     if (ctx.src[y] == ctx.src[ctx.src_pos])

--- a/src/PRS/PRS.cs
+++ b/src/PRS/PRS.cs
@@ -11,8 +11,9 @@ namespace PSO.PRS
         /// Compresses data
         /// </summary>
         /// <param name="data">Uncompressed data</param>
+        /// <param name="searchBufferSize">The number of bytes to search for matching patterns. Range: from 255 (0xFF, fastest) to 8191 (0x1FFF, maximum compression). Default value is 8176 (0x1FF0).</param>
         /// <returns>Returns the compressed data</returns>
-        public static byte[] Compress(byte[] data)
+        public static byte[] Compress(byte[] data, int searchBufferSize = 8176)
         {
             Context ctx = new Context(data);
 


### PR DESCRIPTION
This is a simple change that adds an optional argument to the Compress function that specifies the search buffer size that allows the user to choose between faster or more efficient compression.