### PR TITLE
Use search buffer size in the main class

### DIFF
--- a/src/PRS/PRS.cs
+++ b/src/PRS/PRS.cs
@@ -17,7 +17,7 @@ namespace PSO.PRS
         {
             Context ctx = new Context(data);
 
-            Compression.Compress(ctx);
+            Compression.Compress(ctx, searchBufferSize);
             Array.Resize(ref ctx.dst, ctx.dst_pos);
 
             return ctx.dst;


### PR DESCRIPTION
Hi! It looks like I didn't actually use the `searchBufferSize` argument in the main PRS class when I made the pull request. I have corrected it in this one. Sorry for the trouble. The Nuget package is also affected.